### PR TITLE
fix(web): stub node auth modules and test browser entry

### DIFF
--- a/packages/web/src/platform/stubs/chalk.ts
+++ b/packages/web/src/platform/stubs/chalk.ts
@@ -1,0 +1,8 @@
+/**
+ * Minimal stub for chalk in the browser.
+ * Returns input strings without styling.
+ */
+const handler = {
+  get: () => (str: string) => str,
+};
+export default new Proxy({}, handler);

--- a/packages/web/src/platform/stubs/getPty.ts
+++ b/packages/web/src/platform/stubs/getPty.ts
@@ -1,0 +1,6 @@
+/**
+ * Stub for PTY creation in the browser.
+ */
+export default async function getPty() {
+  throw new Error('PTY is not supported in the browser');
+}

--- a/packages/web/src/platform/stubs/google-auth-library.ts
+++ b/packages/web/src/platform/stubs/google-auth-library.ts
@@ -1,0 +1,19 @@
+/**
+ * Minimal browser stub for google-auth-library.
+ * Provides placeholder classes used by the core library.
+ */
+
+export class OAuth2Client {}
+export class GoogleAuth {
+  // getClient is used in Node environments; here it just throws if called.
+  async getClient(): Promise<never> {
+    throw new Error('GoogleAuth is not available in the browser environment');
+  }
+}
+export class Compute {}
+
+export default {
+  OAuth2Client,
+  GoogleAuth,
+  Compute,
+};

--- a/packages/web/src/platform/stubs/google-logging-utils.ts
+++ b/packages/web/src/platform/stubs/google-logging-utils.ts
@@ -1,0 +1,18 @@
+/**
+ * Minimal browser stub for google-logging-utils used by gcp-metadata.
+ * Returns no-op logging functions.
+ */
+
+export function log() {
+  const fn: any = () => {};
+  fn.info = fn;
+  fn.warn = fn;
+  fn.error = fn;
+  fn.debug = fn;
+  fn.on = () => fn;
+  fn.sublog = () => fn;
+  return fn;
+}
+
+export const env = { nodeEnables: '' };
+export function setBackend() {}

--- a/packages/web/src/test/main.test.ts
+++ b/packages/web/src/test/main.test.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+// Provide minimal mocks for browser-only dependencies
+vi.mock('../terminal/XtermHost.js', () => {
+  return {
+    XtermHost: class {
+      println() {}
+      print() {}
+      printMessage() {}
+      readLine() { return Promise.resolve(''); }
+      focus() {}
+      dispose() {}
+    },
+  };
+});
+
+describe('main entry', () => {
+  it('initializes GeminiWebApp on DOMContentLoaded', async () => {
+    document.body.innerHTML = `
+      <div id="terminal"></div>
+      <div id="status-left"></div>
+    `;
+
+    const mod = await import('../main.js');
+    const { GeminiWebApp } = mod;
+    const startSpy = vi
+      .spyOn(GeminiWebApp.prototype as any, 'start')
+      .mockResolvedValue();
+
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    await Promise.resolve();
+
+    expect(startSpy).toHaveBeenCalled();
+    startSpy.mockRestore();
+  });
+});

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -40,6 +40,8 @@ export default defineConfig({
       '@google/gemini-cli-core/dist/src/utils/getPty.js':
         './src/platform/stubs/getPty.ts',
       chalk: './src/platform/stubs/chalk.ts',
+      'google-auth-library': './src/platform/stubs/google-auth-library.ts',
+      'google-logging-utils': './src/platform/stubs/google-logging-utils.ts',
     },
   },
 });


### PR DESCRIPTION
## Summary
- stub `google-auth-library` and `google-logging-utils` for browser builds
- update vite config with aliases for browser stubs
- add test ensuring `GeminiWebApp` initializes on DOMContentLoaded

## Testing
- `npm run build --workspace=packages/core`
- `npm run test:web`


------
https://chatgpt.com/codex/tasks/task_e_68ac5e71b1c88321927240329d8599ef